### PR TITLE
Add test-report action

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,17 @@
+name: Test Report
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Display test report
+        uses: dorny/test-reporter@v1.6.0
+        with:
+          artifact: test-results
+          name: JUnit Tests
+          path: '**/*.xml'
+          reporter: java-junit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,17 @@ jobs:
     
       - name: Execute Gradle test
         run: ./gradlew test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: success() || failure()
+        with:
+          name: test-results
+          path: build/test-results/**/*.xml
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v2
+        if: success() || failure()
+        with:
+          name: test-report
+          path: build/reports/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
         run: ./gradlew test
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: test-results
           path: build/test-results/**/*.xml
 
       - name: Upload test report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: test-report


### PR DESCRIPTION
* Add [test-report](https://github.com/marketplace/actions/test-reporter) action so that we can see the summary of JUnit test resuls of CI build
* Archive HTML report just in case we need to check the details of JUnit report
* The summary of the `test-report` would look like this:
![test-report-summary](https://github.com/line/thrift-gradle-plugin/assets/537312/991a59eb-ca5f-4ae8-9778-7eb3b3362264)
