### PR TITLE
Add Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+Motivation:
+
+Explain why you're making this change and what problem you're trying to solve.
+
+Modifications:
+
+- List the modifications you've made in detail.
+
+Result:
+
+- Closes #<GitHub issue number>. (If this resolves the issue.)
+- Describe the consequences that a user will face after this PR is merged.
+
+<!--
+Visit this URL to learn more about how to write a pull request description:
+https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
+-->


### PR DESCRIPTION
Motivation:

- Add Github PR template so that contributors can easily know what's required for creating PR

Modifications:

- Add `PULL_REQUEST_TEMPLATE.md` as Github PR template

Result:

- Closes #9 
- All following PR will have built-in template


