### PR TITLE
Fix the bug of not setting default thrift source folder correctly

### DIFF
--- a/src/main/java/org/jruyi/gradle/thrift/plugin/ThriftPlugin.java
+++ b/src/main/java/org/jruyi/gradle/thrift/plugin/ThriftPlugin.java
@@ -41,7 +41,7 @@ public class ThriftPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         final CompileThrift compileThrift = project.getTasks().create(COMPILE_THRIFT_TASK, CompileThrift.class);
-        compileThrift.sourceDir(project.getProjectDir() + "src/main/thrift");
+        compileThrift.sourceDir(project.getProjectDir() + "/src/main/thrift");
         compileThrift.outputDir(project.getBuildDir() + "/generated-sources/thrift");
     }
 }


### PR DESCRIPTION
Motivation:

When testing manually, found that the source folder of thrift is not set correctly. For example if the project is test1 It must be `test1/src/main/thrift` instead of `test1src/main/thrift`

Modifications:

- Add missing '/'  & test for it

Result:

- Make plugin work as expected

