### PR TITLE
Using environment variable to pass gradle publish key and secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
           PLUGIN_VERSION: ${{ github.event.release.tag_name }}
-        run: ./gradlew publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
+        run: ./gradlew publishPlugins

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,24 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
+def setupPluginUpload = tasks.register("setupPluginUpload") {
+    doLast {
+        def key = System.getenv("GRADLE_PUBLISH_KEY")
+        def secret = System.getenv("GRADLE_PUBLISH_SECRET")
+
+        if (key == null || secret == null) {
+            throw new RuntimeException("PublishKey or PublishSecret are not defined from environment variables")
+        }
+
+        System.setProperty("gradle.publish.key", key)
+        System.setProperty("gradle.publish.secret", secret)
+    }
+}
+
+tasks.named("publishPlugins").configure {
+    dependsOn setupPluginUpload
+}
+
 gradlePlugin {
     website = 'https://github.com/line/thrift-gradle-plugin'
     vcsUrl = 'https://github.com/line/thrift-gradle-plugin'


### PR DESCRIPTION
Motivation:

Avoid passing gradle plugin publish key & secret from argument.

Modifications:

- Add new task to read key and secret from environment variable and setting it to system properties
- Make publishPlugins depends on the property setting task

Result:

- Remove the `-Pgradle.publish.key=$GRADLE_PUBLISH_KEY` from command

