### PR TITLE
Update Copyright header to align with other files

### DIFF
--- a/src/main/java/com/linecorp/thrift/plugin/CompileThrift.java
+++ b/src/main/java/com/linecorp/thrift/plugin/CompileThrift.java
@@ -1,4 +1,7 @@
 /*
+ * Based on jruyi/thrift-gradle-plugin/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
+ * Modified 2023 LINE Corporation
+ *
  * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
@@ -12,19 +15,6 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- */
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 package com.linecorp.thrift.plugin;

--- a/src/main/java/com/linecorp/thrift/plugin/ThriftPlugin.java
+++ b/src/main/java/com/linecorp/thrift/plugin/ThriftPlugin.java
@@ -1,4 +1,7 @@
 /*
+ * Based on jruyi/thrift-gradle-plugin/src/main/groovy/org/jruyi/gradle/thrift/plugin/ThriftPlugin.groovy
+ * Modified 2023 LINE Corporation
+ *
  * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
@@ -13,20 +16,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.linecorp.thrift.plugin;
 
 import org.gradle.api.Plugin;


### PR DESCRIPTION
Motivation:

Update Copyright header to align with other files

Modifications:

- Update Copyright header in CompilerThrift.java/ThriftPlugin.java

Result:

- The copyright header should be using the same convention

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
