### PR TITLE
Fix our publish can't get version from tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Gradle Plugin Publish
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [ created ]
 
 jobs:
   publish:


### PR DESCRIPTION
Motivation:

Currently we don't use bot to create release, so it's easier to just use `release` event with `github.event.release.tag_name`

Modifications:

- Using `release` event now.

Result:

- Fix the failed release action
