### PR TITLE
Fix action's publish is not invoked

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Gradle Plugin Publish
 on:
   release:
-    types: [ created ]
+    types: [ published ]
 
 jobs:
   publish:
@@ -22,7 +22,7 @@ jobs:
       - name: Show version number
         id: version
         run: |
-          echo "Version=${{ github.event.release.tag_name }}"
+          echo "Version=${{ github.ref_name }}"
 
       - name: Publish plugins with gradle
         env:


### PR DESCRIPTION
Motivation:

Fix the issue of publish action not invoked.

Modifications:

- Using published instead of created which is not work when I try
- Using `github.ref_name` from the comment of https://github.com/line/thrift-gradle-plugin/pull/20

Result:

- Make publish event works
