### PR TITLE
Supporting gradle configuration cache

### DIFF
--- a/src/test/java/com/linecorp/thrift/plugin/ThriftPluginTest.java
+++ b/src/test/java/com/linecorp/thrift/plugin/ThriftPluginTest.java
@@ -23,7 +23,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.gradle.testkit.runner.BuildResult;
@@ -101,7 +100,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileThrift", "--info"))
+                                               .withArguments("compileThrift", "--info")
                                                .withPluginClasspath()
                                                .build();
         assertThat(gradle.task(":compileThrift").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
@@ -139,7 +138,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -159,6 +158,34 @@ public class ThriftPluginTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "7.6", "8.0", "8.1" })
+    public void generateWithConfigurationCache(String version) throws Exception {
+        copyFile(Paths.get("src/test/resources/test.thrift"), projectDir.resolve("src/main/thrift"));
+        Files.write(buildFile,
+                    Collections.singletonList(
+                            "    compileThrift {\n" +
+                            "        thriftExecutable \"" + thriftPathExpression + "\"\n" +
+                            "    }\n"),
+                    StandardOpenOption.APPEND);
+
+        GradleRunner.create()
+                    .withProjectDir(projectDir.toFile())
+                    .withGradleVersion(version)
+                    .withArguments("--configuration-cache", "compileJava", "--info")
+                    .withPluginClasspath()
+                    .build();
+
+        final BuildResult gradle = GradleRunner.create()
+                                               .withProjectDir(projectDir.toFile())
+                                               .withGradleVersion(version)
+                                               .withArguments("--configuration-cache", "compileJava", "--info")
+                                               .withPluginClasspath()
+                                               .build();
+
+        assertThat(gradle.getOutput()).contains("Reusing configuration cache.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "7.6", "8.0", "8.1" })
     public void disableAutoDetectPlugin(String version) throws Exception {
         copyFile(Paths.get("src/test/resources/test.thrift"), projectDir.resolve("src/main/thrift"));
         Files.write(buildFile,
@@ -172,7 +199,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -205,7 +232,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -239,7 +266,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -275,7 +302,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -318,7 +345,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -365,7 +392,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -414,7 +441,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileJava", "--info"))
+                                               .withArguments("compileJava", "--info")
                                                .withPluginClasspath()
                                                .build();
 
@@ -463,7 +490,7 @@ public class ThriftPluginTest {
         final BuildResult gradle = GradleRunner.create()
                                                .withProjectDir(projectDir.toFile())
                                                .withGradleVersion(version)
-                                               .withArguments(Arrays.asList("compileThrift", "--info"))
+                                               .withArguments("compileThrift", "--info")
                                                .withPluginClasspath()
                                                .build();
         assertThat(gradle.task(":compileThrift").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
@@ -515,7 +542,7 @@ public class ThriftPluginTest {
         final GradleRunner runner = GradleRunner.create()
                                                 .withProjectDir(projectDir.toFile())
                                                 .withGradleVersion(version)
-                                                .withArguments(Arrays.asList("compileThrift", "--info"))
+                                                .withArguments("compileThrift", "--info")
                                                 .withPluginClasspath();
         runner.build();
 


### PR DESCRIPTION
Motivation:

Supporting configuration cache. Currently we have `getProject()` in action, so we need to replace it by suggestion of [doc](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements).

Modifications:

- Replace `project.exec {}` and `project.filetree {}`

Result:

- Plugin can be run with `--configuration-cache`